### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @creativecommons/ct-cc-wordpress-themes-core-committers
+* @creativecommons/web @creativecommons/ct-cc-wordpress-themes-core-committers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @creativecommons/ct-cc-wordpress-themes-core-committers


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.