### PR TITLE
Add tag support for creativecommons.org blog posts widget

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -201,7 +201,8 @@ class Site {
 	function admin_enqueue_scripts() {
 		// admin scripts
 		global $pagenow;
-		if ( is_admin() && ( $pagenow == 'widgets.php' ) ) {
+		$current_screen = get_current_screen();
+		if ( is_admin() && ( $pagenow == 'widgets.php' ) || $current_screen->id == 'dashboard_page_cc-main-site-settings' ) {
 			wp_enqueue_media();
 			wp_enqueue_script( 'script-admin', THEME_JS . '/admin_scripts.js', array( 'jquery' ), self::theme_ver );
 		}

--- a/inc/widgets/cc-org-news.php
+++ b/inc/widgets/cc-org-news.php
@@ -1,14 +1,14 @@
 <?php
 
 class WP_Widget_org_news extends WP_Widget {
-  const CATEGORIES_URL = 'https://creativecommons.org/wp-json/wp/v2/categories';
-  const TAGS_URL = 'https://creativecommons.org/wp-json/wp/v2/tags';
-  const ENTRIES_URL = 'https://creativecommons.org/wp-json/wp/v2/posts';
-  const MEDIA_URL = 'https://creativecommons.org/wp-json/wp/v2/media';
-  const TRANSIENT_PREFIX = 'cc_widget_org_news_';
-  const CC_ORG_BLOG_URL = 'https://creativecommons.org/blog';
+	const CATEGORIES_URL   = 'https://creativecommons.org/wp-json/wp/v2/categories';
+	const TAGS_URL         = 'https://creativecommons.org/wp-json/wp/v2/tags';
+	const ENTRIES_URL      = 'https://creativecommons.org/wp-json/wp/v2/posts';
+	const MEDIA_URL        = 'https://creativecommons.org/wp-json/wp/v2/media';
+	const TRANSIENT_PREFIX = 'cc_widget_org_news_';
+	const CC_ORG_BLOG_URL  = 'https://creativecommons.org/blog';
 
-  public $per_page_categories = 50;
+	public $per_page_categories = 50;
 
 	/** constructor */
 	function __construct() {
@@ -19,72 +19,72 @@ class WP_Widget_org_news extends WP_Widget {
 		$control_ops = array();
 		parent::__construct( 'widget-org-news', 'CC Org Last news', $widget_ops, $control_ops );
 	}
-  public function query_api( $url ) {
-    $response = wp_remote_get( $url );
-    $http_code = wp_remote_retrieve_response_code( $response );
-    if ( $http_code == 200 ) {
-      $api_response  = json_decode(wp_remote_retrieve_body( $response ));
-      return $api_response;
-    } else {
-      return false;
-    }
-  }
-	function get_last_news( $size, $category, $tag ) {
-    if ( false === ( $get_entries = get_transient( self::TRANSIENT_PREFIX. $this->id . '_entries' ) ) ) {
-      $entries_url = self::ENTRIES_URL.'?per_page='.$size;
-      if ( !empty( $category ) ) {
-        $entries_url .= '&categories='.$category;
-      }
-      if ( !empty( $tag ) ) {
-        $entries_url .= '&tags='.$tag;
-      }
-
-      $get_entries = $this->query_api( $entries_url );
-      if ( !empty( $get_entries ) ) {
-        $modified_entries = array();
-        foreach ( $get_entries as $entry ) {
-          if ( !empty( $entry->featured_media ) ) {
-            $api_response = $this->query_api( self::MEDIA_URL.'/'. $entry->featured_media );
-            if ( !empty( $api_response ) ) {
-              $entry->featured_media_url = $api_response->media_details->sizes->cc_list_post_thumbnail->source_url;
-              $entry->featured_media_url_full = $api_response->media_details->sizes->full->source_url;
-            }
-          }
-          $modified_entries[] = $entry;
-        }
-        $get_entries = $modified_entries;
-        set_transient( self::TRANSIENT_PREFIX. $this->id . '_entries', $get_entries, HOUR_IN_SECONDS );
-      }
-    }
-    return $get_entries;
+	public function query_api( $url ) {
+		$response  = wp_remote_get( $url );
+		$http_code = wp_remote_retrieve_response_code( $response );
+		if ( $http_code == 200 ) {
+			$api_response = json_decode( wp_remote_retrieve_body( $response ) );
+			return $api_response;
+		} else {
+			return false;
+		}
 	}
-  function get_ccorg_categories() {
-    if ( false === ( $get_categories = get_transient( self::TRANSIENT_PREFIX. $this->id . '_categories' ) ) ) {
-      $api_response = $this->query_api( self::CATEGORIES_URL.'?per_page='.$this->per_page_categories );
-      foreach ( $api_response as $category ) {
-        $get_categories[$category->id] =  array( 
-          'name' => $category->name,
-          'link' => $category->link
-        );
-      }
-      set_transient( self::TRANSIENT_PREFIX . 'categories', $get_categories, HOUR_IN_SECONDS );
-    }
-    return $get_categories;
-  }
-  function get_tag_id( $tag_slug ) {
-    $api_response = $this->query_api( self::TAGS_URL.'?slug='.$tag_slug );
-    if ( !empty( $api_response ) ) {
-      return $api_response[0]->id;
-    }
-  }
+	function get_last_news( $size, $category, $tag ) {
+		if ( false === ( $get_entries = get_transient( self::TRANSIENT_PREFIX . $this->id . '_entries' ) ) ) {
+			$entries_url = self::ENTRIES_URL . '?per_page=' . $size;
+			if ( ! empty( $category ) ) {
+				$entries_url .= '&categories=' . $category;
+			}
+			if ( ! empty( $tag ) ) {
+				$entries_url .= '&tags=' . $tag;
+			}
+
+			$get_entries = $this->query_api( $entries_url );
+			if ( ! empty( $get_entries ) ) {
+				$modified_entries = array();
+				foreach ( $get_entries as $entry ) {
+					if ( ! empty( $entry->featured_media ) ) {
+						$api_response = $this->query_api( self::MEDIA_URL . '/' . $entry->featured_media );
+						if ( ! empty( $api_response ) ) {
+							$entry->featured_media_url      = $api_response->media_details->sizes->cc_list_post_thumbnail->source_url;
+							$entry->featured_media_url_full = $api_response->media_details->sizes->full->source_url;
+						}
+					}
+					$modified_entries[] = $entry;
+				}
+				$get_entries = $modified_entries;
+				set_transient( self::TRANSIENT_PREFIX . $this->id . '_entries', $get_entries, HOUR_IN_SECONDS );
+			}
+		}
+		return $get_entries;
+	}
+	function get_ccorg_categories() {
+		if ( false === ( $get_categories = get_transient( self::TRANSIENT_PREFIX . $this->id . '_categories' ) ) ) {
+			$api_response = $this->query_api( self::CATEGORIES_URL . '?per_page=' . $this->per_page_categories );
+			foreach ( $api_response as $category ) {
+				$get_categories[ $category->id ] = array(
+					'name' => $category->name,
+					'link' => $category->link,
+				);
+			}
+			set_transient( self::TRANSIENT_PREFIX . 'categories', $get_categories, HOUR_IN_SECONDS );
+		}
+		return $get_categories;
+	}
+	function get_tag_id( $tag_slug ) {
+		$api_response = $this->query_api( self::TAGS_URL . '?slug=' . $tag_slug );
+		if ( ! empty( $api_response ) ) {
+			return $api_response[0]->id;
+		}
+	}
 	function widget( $args, $instance ) {
 		global $post;
 		$size         = ( ! empty( $instance['size'] ) ) ? $instance['size'] : 3;
 		$the_category = ( ! empty( $instance['category'] ) ) ? $instance['category'] : null;
 		$link_text    = ( ! empty( $instance['link_text'] ) ) ? $instance['link_text'] : 'More news';
-    $tag          = ( ! empty( $instance['tag_id'] ) ) ? $instance['tag_id'] : false;
+		$tag          = ( ! empty( $instance['tag_id'] ) ) ? $instance['tag_id'] : false;
 		$news         = $this->get_last_news( $size, $the_category, $tag );
-    $categories   = $this->get_ccorg_categories();
+		$categories   = $this->get_ccorg_categories();
 		if ( ! empty( $news ) ) {
 			echo '<div class="widget news">';
 			echo '<header class="widget-header">';
@@ -92,7 +92,7 @@ class WP_Widget_org_news extends WP_Widget {
 				echo '<h2 class="widget-title">' . esc_attr( $instance['title'] ) . '</h2>';
 			}
 			if ( ! empty( $instance['is_link'] && ( ! empty( $instance['category'] ) ) ) ) {
-				$link = !empty( $instance['category'] ) ? $categories[$instance['category']] : self::CC_ORG_BLOG_URL;
+				$link = ! empty( $instance['category'] ) ? $categories[ $instance['category'] ] : self::CC_ORG_BLOG_URL;
 				echo '<div class="more-news">';
 				echo '<a href="' . $link['link'] . '" class="widget-more" target="_blank">' . $link_text . '<i class="icon chevron-right"></i></a>';
 				echo '</div>';
@@ -100,26 +100,26 @@ class WP_Widget_org_news extends WP_Widget {
 			echo '</header>';
 			echo '<div class="widget-content">';
 			foreach ( $news as $item ) {
-        $thumb_url = ( !empty( $item->featured_media ) ) ? $item->featured_media_url : '';
+				$thumb_url = ( ! empty( $item->featured_media ) ) ? $item->featured_media_url : '';
 				echo Components::simple_entry( $item->ID, false, true, true, $item->title->rendered, $thumb_url, $item->date, $item->link, $item->excerpt->rendered );
 			}
 			echo '</div>';
 			echo '</div>';
 		}
 	}
-  
+
 	function update( $new_instance, $old_instance ) {
-    if ( !empty( $new_instance['tag'] ) ) {
-      $new_instance['tag_id'] = $this->get_tag_id( $new_instance['tag'] );
-      if ( !empty( $new_instance['tag_id'] ) ) {
-        $new_instance['tag_remote_exists'] = 1;
-      } else {
-        $new_instance['tag_remote_exists'] = 0;
-      }
-    } 
-    delete_transient( self::TRANSIENT_PREFIX. $this->id . '_categories' );
-    delete_transient( self::TRANSIENT_PREFIX. $this->id . '_entries' );
-    delete_transient( self::TRANSIENT_PREFIX . '_thumbnails' );
+		if ( ! empty( $new_instance['tag'] ) ) {
+			$new_instance['tag_id'] = $this->get_tag_id( $new_instance['tag'] );
+			if ( ! empty( $new_instance['tag_id'] ) ) {
+				$new_instance['tag_remote_exists'] = 1;
+			} else {
+				$new_instance['tag_remote_exists'] = 0;
+			}
+		}
+		delete_transient( self::TRANSIENT_PREFIX . $this->id . '_categories' );
+		delete_transient( self::TRANSIENT_PREFIX . $this->id . '_entries' );
+		delete_transient( self::TRANSIENT_PREFIX . '_thumbnails' );
 		return $new_instance;
 	}
 
@@ -130,18 +130,18 @@ class WP_Widget_org_news extends WP_Widget {
 		echo '<p><label for="' . $this->get_field_name( 'is_link' ) . '">Link to news archive? </label><input type="checkbox" id="' . $this->get_field_id( 'is_link' ) . '"' . ( ( ! empty( $is_link ) ) ? ' checked="checked" ' : '' ) . ' name="' . $this->get_field_name( 'is_link' ) . '" value="1"></p>';
 		echo '<p><label for="' . $this->get_field_id( 'link_text' ) . '">Link text: <input type="text" name="' . $this->get_field_name( 'link_text' ) . '" id="' . $this->get_field_id( 'link_text' ) . '" value="' . $instance['link_text'] . '" class="widefat"/></label></p>';
 		echo '<p><label for="' . $this->get_field_id( 'size' ) . '">Entries number: <input type="number" name="' . $this->get_field_name( 'size' ) . '" id="' . $this->get_field_id( 'size' ) . '" value="' . $instance['size'] . '"/></label></p>';
-    $tag_error = ( !$instance['tag_remote_exists'] ) ? '<small style="color:red;">The tag doesn\'t seems to exists in the source website</small>' : '';
-    echo '<p><label for="' . $this->get_field_id( 'tag' ) . '">Tag slug: <input type="text" name="' . $this->get_field_name( 'tag' ) . '" id="' . $this->get_field_id( 'tag' ) . '" value="' . $instance['tag'] . '"/></label>'.$tag_error.'</p>';
-    echo '<input type="hidden" name="' . $this->get_field_name( 'tag_id' ) . ' value="' . $instance['tag_id'] . '"/>';
-    echo '<input type="hidden" name="' . $this->get_field_name( 'tag_remote_exists' ) . ' value="' . $instance['tag_remote_exists'] . '"/>';
+		$tag_error = ( ! $instance['tag_remote_exists'] ) ? '<small style="color:red;">The tag doesn\'t seems to exists in the source website</small>' : '';
+		echo '<p><label for="' . $this->get_field_id( 'tag' ) . '">Tag slug: <input type="text" name="' . $this->get_field_name( 'tag' ) . '" id="' . $this->get_field_id( 'tag' ) . '" value="' . $instance['tag'] . '"/></label>' . $tag_error . '</p>';
+		echo '<input type="hidden" name="' . $this->get_field_name( 'tag_id' ) . ' value="' . $instance['tag_id'] . '"/>';
+		echo '<input type="hidden" name="' . $this->get_field_name( 'tag_remote_exists' ) . ' value="' . $instance['tag_remote_exists'] . '"/>';
 		echo '<p><label for="' . $this->get_field_id( 'category' ) . '">Category: ';
-    $get_categories = $this->get_ccorg_categories();
-    echo '<p><select name="'.$this->get_field_name( 'category' ).'" id="'.$this->get_field_id( 'category' ).'">';
-      foreach ( $get_categories as $key => $category ) {
-        $selected = ( $key == $instance['category'] ) ? 'selected = "selected" ' : '';
-        echo '<option value="'.$key.'" '.$selected.'>'.$category['name'].'</option>';
-      }
-    echo '</select>';
+		$get_categories = $this->get_ccorg_categories();
+		echo '<p><select name="' . $this->get_field_name( 'category' ) . '" id="' . $this->get_field_id( 'category' ) . '">';
+		foreach ( $get_categories as $key => $category ) {
+			$selected = ( $key == $instance['category'] ) ? 'selected = "selected" ' : '';
+			echo '<option value="' . $key . '" ' . $selected . '>' . $category['name'] . '</option>';
+		}
+		echo '</select>';
 		echo '</label></p>';
 	}
 }

--- a/inc/widgets/cc-org-news.php
+++ b/inc/widgets/cc-org-news.php
@@ -1,13 +1,14 @@
 <?php
 
 class WP_Widget_org_news extends WP_Widget {
-	const CATEGORIES_URL   = 'https://creativecommons.org/wp-json/wp/v2/categories';
-	const ENTRIES_URL      = 'https://creativecommons.org/wp-json/wp/v2/posts';
-	const MEDIA_URL        = 'https://creativecommons.org/wp-json/wp/v2/media';
-	const TRANSIENT_PREFIX = 'cc_widget_org_news_';
-	const CC_ORG_BLOG_URL  = 'https://creativecommons.org/blog';
+  const CATEGORIES_URL = 'https://creativecommons.org/wp-json/wp/v2/categories';
+  const TAGS_URL = 'https://creativecommons.org/wp-json/wp/v2/tags';
+  const ENTRIES_URL = 'https://creativecommons.org/wp-json/wp/v2/posts';
+  const MEDIA_URL = 'https://creativecommons.org/wp-json/wp/v2/media';
+  const TRANSIENT_PREFIX = 'cc_widget_org_news_';
+  const CC_ORG_BLOG_URL = 'https://creativecommons.org/blog';
 
-	public $per_page_categories = 50;
+  public $per_page_categories = 50;
 
 	/** constructor */
 	function __construct() {
@@ -18,63 +19,72 @@ class WP_Widget_org_news extends WP_Widget {
 		$control_ops = array();
 		parent::__construct( 'widget-org-news', 'CC Org Last news', $widget_ops, $control_ops );
 	}
-	public function query_api( $url ) {
-		$response  = wp_remote_get( $url );
-		$http_code = wp_remote_retrieve_response_code( $response );
-		if ( $http_code == 200 ) {
-			$api_response = json_decode( wp_remote_retrieve_body( $response ) );
-			return $api_response;
-		} else {
-			return false;
-		}
-	}
-	function get_last_news( $size, $category ) {
-		if ( false === ( $get_entries = get_transient( self::TRANSIENT_PREFIX . $this->id . '_entries' ) ) ) {
-			$entries_url = self::ENTRIES_URL . '?per_page=' . $size;
-			if ( ! empty( $category ) ) {
-				$entries_url .= '&categories=' . $category;
-			}
+  public function query_api( $url ) {
+    $response = wp_remote_get( $url );
+    $http_code = wp_remote_retrieve_response_code( $response );
+    if ( $http_code == 200 ) {
+      $api_response  = json_decode(wp_remote_retrieve_body( $response ));
+      return $api_response;
+    } else {
+      return false;
+    }
+  }
+	function get_last_news( $size, $category, $tag ) {
+    if ( false === ( $get_entries = get_transient( self::TRANSIENT_PREFIX. $this->id . '_entries' ) ) ) {
+      $entries_url = self::ENTRIES_URL.'?per_page='.$size;
+      if ( !empty( $category ) ) {
+        $entries_url .= '&categories='.$category;
+      }
+      if ( !empty( $tag ) ) {
+        $entries_url .= '&tags='.$tag;
+      }
 
-			$get_entries = $this->query_api( $entries_url );
-			if ( ! empty( $get_entries ) ) {
-				$modified_entries = array();
-				foreach ( $get_entries as $entry ) {
-					if ( ! empty( $entry->featured_media ) ) {
-						$api_response = $this->query_api( self::MEDIA_URL . '/' . $entry->featured_media );
-						if ( ! empty( $api_response ) ) {
-							  $entry->featured_media_url      = $api_response->media_details->sizes->cc_list_post_thumbnail->source_url;
-							  $entry->featured_media_url_full = $api_response->media_details->sizes->full->source_url;
-						}
-					}
-					$modified_entries[] = $entry;
-				}
-				$get_entries = $modified_entries;
-				set_transient( self::TRANSIENT_PREFIX . $this->id . '_entries', $get_entries, HOUR_IN_SECONDS );
-			}
-		}
-		return $get_entries;
+      $get_entries = $this->query_api( $entries_url );
+      if ( !empty( $get_entries ) ) {
+        $modified_entries = array();
+        foreach ( $get_entries as $entry ) {
+          if ( !empty( $entry->featured_media ) ) {
+            $api_response = $this->query_api( self::MEDIA_URL.'/'. $entry->featured_media );
+            if ( !empty( $api_response ) ) {
+              $entry->featured_media_url = $api_response->media_details->sizes->cc_list_post_thumbnail->source_url;
+              $entry->featured_media_url_full = $api_response->media_details->sizes->full->source_url;
+            }
+          }
+          $modified_entries[] = $entry;
+        }
+        $get_entries = $modified_entries;
+        set_transient( self::TRANSIENT_PREFIX. $this->id . '_entries', $get_entries, HOUR_IN_SECONDS );
+      }
+    }
+    return $get_entries;
 	}
-	function get_ccorg_categories() {
-		if ( false === ( $get_categories = get_transient( self::TRANSIENT_PREFIX . $this->id . '_categories' ) ) ) {
-			$api_response = $this->query_api( self::CATEGORIES_URL . '?per_page=' . $this->per_page_categories );
-			foreach ( $api_response as $category ) {
-				$get_categories[ $category->id ] = array(
-					'name' => $category->name,
-					'link' => $category->link,
-				);
-			}
-			set_transient( self::TRANSIENT_PREFIX . 'categories', $get_categories, HOUR_IN_SECONDS );
-		}
-		return $get_categories;
-	}
-
+  function get_ccorg_categories() {
+    if ( false === ( $get_categories = get_transient( self::TRANSIENT_PREFIX. $this->id . '_categories' ) ) ) {
+      $api_response = $this->query_api( self::CATEGORIES_URL.'?per_page='.$this->per_page_categories );
+      foreach ( $api_response as $category ) {
+        $get_categories[$category->id] =  array( 
+          'name' => $category->name,
+          'link' => $category->link
+        );
+      }
+      set_transient( self::TRANSIENT_PREFIX . 'categories', $get_categories, HOUR_IN_SECONDS );
+    }
+    return $get_categories;
+  }
+  function get_tag_id( $tag_slug ) {
+    $api_response = $this->query_api( self::TAGS_URL.'?slug='.$tag_slug );
+    if ( !empty( $api_response ) ) {
+      return $api_response[0]->id;
+    }
+  }
 	function widget( $args, $instance ) {
 		global $post;
 		$size         = ( ! empty( $instance['size'] ) ) ? $instance['size'] : 3;
 		$the_category = ( ! empty( $instance['category'] ) ) ? $instance['category'] : null;
 		$link_text    = ( ! empty( $instance['link_text'] ) ) ? $instance['link_text'] : 'More news';
-		$news         = $this->get_last_news( $size, $the_category );
-		$categories   = $this->get_ccorg_categories();
+    $tag          = ( ! empty( $instance['tag_id'] ) ) ? $instance['tag_id'] : false;
+		$news         = $this->get_last_news( $size, $the_category, $tag );
+    $categories   = $this->get_ccorg_categories();
 		if ( ! empty( $news ) ) {
 			echo '<div class="widget news">';
 			echo '<header class="widget-header">';
@@ -82,7 +92,7 @@ class WP_Widget_org_news extends WP_Widget {
 				echo '<h2 class="widget-title">' . esc_attr( $instance['title'] ) . '</h2>';
 			}
 			if ( ! empty( $instance['is_link'] && ( ! empty( $instance['category'] ) ) ) ) {
-				$link = ! empty( $instance['category'] ) ? $categories[ $instance['category'] ] : self::CC_ORG_BLOG_URL;
+				$link = !empty( $instance['category'] ) ? $categories[$instance['category']] : self::CC_ORG_BLOG_URL;
 				echo '<div class="more-news">';
 				echo '<a href="' . $link['link'] . '" class="widget-more" target="_blank">' . $link_text . '<i class="icon chevron-right"></i></a>';
 				echo '</div>';
@@ -90,18 +100,26 @@ class WP_Widget_org_news extends WP_Widget {
 			echo '</header>';
 			echo '<div class="widget-content">';
 			foreach ( $news as $item ) {
-				$thumb_url = ( ! empty( $item->featured_media ) ) ? $item->featured_media_url : '';
+        $thumb_url = ( !empty( $item->featured_media ) ) ? $item->featured_media_url : '';
 				echo Components::simple_entry( $item->ID, false, true, true, $item->title->rendered, $thumb_url, $item->date, $item->link, $item->excerpt->rendered );
 			}
 			echo '</div>';
 			echo '</div>';
 		}
 	}
-
+  
 	function update( $new_instance, $old_instance ) {
-		delete_transient( self::TRANSIENT_PREFIX . $this->id . '_categories' );
-		delete_transient( self::TRANSIENT_PREFIX . $this->id . '_entries' );
-		delete_transient( self::TRANSIENT_PREFIX . '_thumbnails' );
+    if ( !empty( $new_instance['tag'] ) ) {
+      $new_instance['tag_id'] = $this->get_tag_id( $new_instance['tag'] );
+      if ( !empty( $new_instance['tag_id'] ) ) {
+        $new_instance['tag_remote_exists'] = 1;
+      } else {
+        $new_instance['tag_remote_exists'] = 0;
+      }
+    } 
+    delete_transient( self::TRANSIENT_PREFIX. $this->id . '_categories' );
+    delete_transient( self::TRANSIENT_PREFIX. $this->id . '_entries' );
+    delete_transient( self::TRANSIENT_PREFIX . '_thumbnails' );
 		return $new_instance;
 	}
 
@@ -112,14 +130,18 @@ class WP_Widget_org_news extends WP_Widget {
 		echo '<p><label for="' . $this->get_field_name( 'is_link' ) . '">Link to news archive? </label><input type="checkbox" id="' . $this->get_field_id( 'is_link' ) . '"' . ( ( ! empty( $is_link ) ) ? ' checked="checked" ' : '' ) . ' name="' . $this->get_field_name( 'is_link' ) . '" value="1"></p>';
 		echo '<p><label for="' . $this->get_field_id( 'link_text' ) . '">Link text: <input type="text" name="' . $this->get_field_name( 'link_text' ) . '" id="' . $this->get_field_id( 'link_text' ) . '" value="' . $instance['link_text'] . '" class="widefat"/></label></p>';
 		echo '<p><label for="' . $this->get_field_id( 'size' ) . '">Entries number: <input type="number" name="' . $this->get_field_name( 'size' ) . '" id="' . $this->get_field_id( 'size' ) . '" value="' . $instance['size'] . '"/></label></p>';
+    $tag_error = ( !$instance['tag_remote_exists'] ) ? '<small style="color:red;">The tag doesn\'t seems to exists in the source website</small>' : '';
+    echo '<p><label for="' . $this->get_field_id( 'tag' ) . '">Tag slug: <input type="text" name="' . $this->get_field_name( 'tag' ) . '" id="' . $this->get_field_id( 'tag' ) . '" value="' . $instance['tag'] . '"/></label>'.$tag_error.'</p>';
+    echo '<input type="hidden" name="' . $this->get_field_name( 'tag_id' ) . ' value="' . $instance['tag_id'] . '"/>';
+    echo '<input type="hidden" name="' . $this->get_field_name( 'tag_remote_exists' ) . ' value="' . $instance['tag_remote_exists'] . '"/>';
 		echo '<p><label for="' . $this->get_field_id( 'category' ) . '">Category: ';
-		$get_categories = $this->get_ccorg_categories();
-		echo '<p><select name="' . $this->get_field_name( 'category' ) . '" id="' . $this->get_field_id( 'category' ) . '">';
-		foreach ( $get_categories as $key => $category ) {
-			$selected = ( $key == $instance['category'] ) ? 'selected = "selected" ' : '';
-			echo '<option value="' . $key . '" ' . $selected . '>' . $category['name'] . '</option>';
-		}
-		echo '</select>';
+    $get_categories = $this->get_ccorg_categories();
+    echo '<p><select name="'.$this->get_field_name( 'category' ).'" id="'.$this->get_field_id( 'category' ).'">';
+      foreach ( $get_categories as $key => $category ) {
+        $selected = ( $key == $instance['category'] ) ? 'selected = "selected" ' : '';
+        echo '<option value="'.$key.'" '.$selected.'>'.$category['name'].'</option>';
+      }
+    echo '</select>';
 		echo '</label></p>';
 	}
 }


### PR DESCRIPTION
## Description
This PR adds tag support to filter entries from the creativecommons.org website in the cc.org news widget


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
